### PR TITLE
feat/loading spinner

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -49,6 +49,10 @@ export const keyframes = defineKeyframes({
     from: { opacity: 0 },
     to: { opacity: 1 },
   },
+  rotate: {
+    '0%': { transform: 'rotate(0deg)' },
+    '100%': { transform: 'rotate(360deg)' },
+  },
 });
 
 export default defineConfig({

--- a/src/ui/Image.tsx
+++ b/src/ui/Image.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, type SyntheticEvent } from 'react';
 import { styled } from 'styled-system/jsx';
-import type { JsxStyleProps } from 'styled-system/types';
+import type { HTMLStyledProps } from 'styled-system/types';
 
 export type ImageTransformOptions = {
   blur?: number;
@@ -39,7 +39,7 @@ const Img = styled('img', {
   },
 });
 
-export interface ImageProps extends JsxStyleProps {
+export type ImageProps = HTMLStyledProps<'img'> & {
   alt?: string;
   loading?: 'lazy' | 'eager';
   options?: ImageTransformOptions;
@@ -47,7 +47,7 @@ export interface ImageProps extends JsxStyleProps {
   srcSet?: string;
   useAnimation?: boolean;
   useHighRes?: boolean;
-}
+};
 
 export const Image = (props: ImageProps) => {
   const {
@@ -56,10 +56,17 @@ export const Image = (props: ImageProps) => {
     src: initialSrc,
     useAnimation = false,
     useHighRes,
+    onLoad,
     ...imgProps
   } = props;
   const [hasLoaded, setHasLoaded] = useState(false);
-  const handleLoad = useCallback(() => setHasLoaded(true), []);
+  const handleLoad = useCallback(
+    (e: SyntheticEvent<HTMLImageElement>) => {
+      setHasLoaded(true);
+      onLoad?.(e);
+    },
+    [onLoad],
+  );
   const { src, srcSet } = useMemo<{
     src: string;
     srcSet: string | undefined;

--- a/src/ui/Loader.tsx
+++ b/src/ui/Loader.tsx
@@ -1,0 +1,66 @@
+import { cva, type RecipeVariantProps } from 'styled-system/css';
+import { Box, styled, type BoxProps } from 'styled-system/jsx';
+import type { SystemStyleObject } from 'styled-system/types';
+
+const makeVariantStyles = (size: string): SystemStyleObject => ({
+  width: size,
+  height: size,
+  '& div': {
+    width: `calc(${size} * 0.8)`,
+    height: `calc(${size} * 0.8)`,
+    margin: `calc(${size} * 0.1)`,
+    borderWidth: `calc(${size} * 0.1)`,
+  },
+});
+
+export const loaderStyle = cva({
+  base: {
+    display: 'inline-block',
+    position: 'relative',
+    '& div': {
+      animation: 'rotate 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite',
+      borderColor: 'currentColor transparent transparent transparent',
+      borderRadius: '50%',
+      borderStyle: 'solid',
+      boxSizing: 'border-box',
+      display: 'block',
+      position: 'absolute',
+    },
+    '& div:nth-child(1)': {
+      animationDelay: '-0.45s',
+    },
+    '& div:nth-child(2)': {
+      animationDelay: '-0.3s',
+    },
+    '& div:nth-child(3)': {
+      animationDelay: '-0.15s',
+    },
+  },
+  variants: {
+    size: {
+      sm: makeVariantStyles('1.5rem'),
+      md: makeVariantStyles('2.5rem'),
+      lg: makeVariantStyles('3.5rem'),
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+const InnerLoader = styled(Box, loaderStyle);
+
+export type LoaderVariantProps = RecipeVariantProps<typeof loaderStyle>;
+export type LoaderProps = BoxProps & LoaderVariantProps;
+
+export const Loader = (props: LoaderProps) => {
+  const { color = 'zinc.900', size = 'md', ...loaderProps } = props;
+
+  return (
+    <InnerLoader color={color} size={size} {...loaderProps}>
+      {new Array(4).fill(null).map((_, i) => (
+        <styled.div key={i} />
+      ))}
+    </InnerLoader>
+  );
+};


### PR DESCRIPTION
Adds a cute loading spinner component with deferred overlay on project hovers.
This lets the spinner show for slower networks while avoiding the wonky flash for cached images.